### PR TITLE
Add Exchange API with status, schedule, and announcements

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,7 @@
 //! through flat methods on [`KalshiClient`](crate::KalshiClient).
 
 mod events;
-mod exchange;
+pub(crate) mod exchange;
 mod markets;
 mod orders;
 pub(crate) mod portfolio;

--- a/src/api/exchange.rs
+++ b/src/api/exchange.rs
@@ -1,1 +1,49 @@
-// Exchange API endpoints
+//! Exchange API endpoints.
+//!
+//! This module provides functions for interacting with the Kalshi Exchange API,
+//! including exchange status, schedule, announcements, and user data timestamps.
+
+use crate::{
+    client::HttpClient,
+    error::Result,
+    models::{
+        ExchangeAnnouncementsResponse, ExchangeScheduleResponse, ExchangeStatusResponse,
+        UserDataTimestampResponse,
+    },
+};
+
+/// Get the current exchange status.
+///
+/// Returns whether the exchange and trading are currently active.
+/// This is a public endpoint that does not require authentication.
+pub async fn get_exchange_status(http: &HttpClient) -> Result<ExchangeStatusResponse> {
+    http.get("/exchange/status").await
+}
+
+/// Get the exchange schedule.
+///
+/// Returns the weekly trading schedule and any scheduled maintenance windows.
+/// All times are in Eastern Time (ET).
+/// This is a public endpoint that does not require authentication.
+pub async fn get_exchange_schedule(http: &HttpClient) -> Result<ExchangeScheduleResponse> {
+    http.get("/exchange/schedule").await
+}
+
+/// Get exchange announcements.
+///
+/// Returns all exchange-wide announcements including info, warning, and error messages.
+/// This is a public endpoint that does not require authentication.
+pub async fn get_exchange_announcements(
+    http: &HttpClient,
+) -> Result<ExchangeAnnouncementsResponse> {
+    http.get("/exchange/announcements").await
+}
+
+/// Get the user data timestamp.
+///
+/// Returns an approximate indication of when user portfolio data
+/// (balance, orders, fills, positions) was last validated.
+/// Useful for determining data freshness.
+pub async fn get_user_data_timestamp(http: &HttpClient) -> Result<UserDataTimestampResponse> {
+    http.get("/exchange/user_data_timestamp").await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,12 @@ pub use auth::KalshiConfig;
 pub use client::{Environment, HttpClient, KalshiClient};
 pub use error::{Error, Result};
 pub use models::{
-    Action, BalanceResponse, EventPosition, Fill, FillsResponse, GetFillsParams, GetOrdersParams,
-    GetPositionsParams, MarketPosition, Order, OrderStatus, OrderType, OrdersResponse,
-    PositionsResponse, SelfTradePreventionType, Side, cents_to_dollars,
+    Action, Announcement, AnnouncementStatus, AnnouncementType, BalanceResponse, EventPosition,
+    ExchangeAnnouncementsResponse, ExchangeSchedule, ExchangeScheduleResponse,
+    ExchangeStatusResponse, Fill, FillsResponse, GetFillsParams, GetOrdersParams,
+    GetPositionsParams, MaintenanceWindow, MarketPosition, Order, OrderStatus, OrderType,
+    OrdersResponse, PositionsResponse, SelfTradePreventionType, Side, StandardHoursPeriod,
+    TradingSession, UserDataTimestampResponse, cents_to_dollars,
 };
 
 // Re-export WebSocket types for convenience

--- a/src/models/exchange.rs
+++ b/src/models/exchange.rs
@@ -1,0 +1,159 @@
+//! Exchange models and response types.
+//!
+//! Types for exchange status, schedule, announcements, and data timestamps.
+
+use serde::{Deserialize, Serialize};
+
+/// Response from the GET /exchange/status endpoint.
+///
+/// Indicates whether the exchange and trading are currently active.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeStatusResponse {
+    /// Indicates if the core exchange accepts state changes.
+    /// Returns false during maintenance; true otherwise.
+    /// Covers trading, new users, and transfers.
+    pub exchange_active: bool,
+
+    /// Indicates if trading is currently permitted.
+    /// True during exchange hours; false outside trading hours or during pauses.
+    pub trading_active: bool,
+
+    /// RFC3339 timestamp indicating estimated maintenance completion.
+    /// Not guaranteed and subject to extension.
+    #[serde(default)]
+    pub exchange_estimated_resume_time: Option<String>,
+}
+
+/// Response from the GET /exchange/schedule endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeScheduleResponse {
+    /// The exchange schedule configuration.
+    pub schedule: ExchangeSchedule,
+}
+
+/// Exchange schedule containing standard hours and maintenance windows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeSchedule {
+    /// Weekly trading schedule periods with effective date ranges.
+    pub standard_hours: Vec<StandardHoursPeriod>,
+
+    /// Scheduled maintenance periods when the exchange may be unavailable.
+    #[serde(default)]
+    pub maintenance_windows: Vec<MaintenanceWindow>,
+}
+
+/// A period of standard trading hours with its effective date range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StandardHoursPeriod {
+    /// Start of the period when these hours are effective (RFC3339).
+    #[serde(default)]
+    pub start_time: Option<String>,
+
+    /// End of the period when these hours are effective (RFC3339).
+    #[serde(default)]
+    pub end_time: Option<String>,
+
+    /// Monday trading sessions.
+    #[serde(default)]
+    pub monday: Vec<TradingSession>,
+
+    /// Tuesday trading sessions.
+    #[serde(default)]
+    pub tuesday: Vec<TradingSession>,
+
+    /// Wednesday trading sessions.
+    #[serde(default)]
+    pub wednesday: Vec<TradingSession>,
+
+    /// Thursday trading sessions.
+    #[serde(default)]
+    pub thursday: Vec<TradingSession>,
+
+    /// Friday trading sessions.
+    #[serde(default)]
+    pub friday: Vec<TradingSession>,
+
+    /// Saturday trading sessions.
+    #[serde(default)]
+    pub saturday: Vec<TradingSession>,
+
+    /// Sunday trading sessions.
+    #[serde(default)]
+    pub sunday: Vec<TradingSession>,
+}
+
+/// A trading session with open and close times.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradingSession {
+    /// Session open time in HH:MM format (ET).
+    pub open_time: String,
+
+    /// Session close time in HH:MM format (ET).
+    pub close_time: String,
+}
+
+/// A scheduled maintenance window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaintenanceWindow {
+    /// Start of maintenance window (RFC3339).
+    pub start_datetime: String,
+
+    /// End of maintenance window (RFC3339).
+    pub end_datetime: String,
+}
+
+/// Response from the GET /exchange/announcements endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeAnnouncementsResponse {
+    /// A list of exchange-wide announcements.
+    pub announcements: Vec<Announcement>,
+}
+
+/// An exchange-wide announcement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Announcement {
+    /// The type of the announcement.
+    #[serde(rename = "type")]
+    pub announcement_type: AnnouncementType,
+
+    /// The message contained within the announcement.
+    pub message: String,
+
+    /// The time the announcement was delivered (RFC3339).
+    pub delivery_time: String,
+
+    /// The current status of this announcement.
+    pub status: AnnouncementStatus,
+}
+
+/// Type of an announcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnnouncementType {
+    /// Informational announcement.
+    Info,
+    /// Warning announcement.
+    Warning,
+    /// Error/critical announcement.
+    Error,
+}
+
+/// Status of an announcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnnouncementStatus {
+    /// Announcement is currently active.
+    Active,
+    /// Announcement is no longer active.
+    Inactive,
+}
+
+/// Response from the GET /exchange/user_data_timestamp endpoint.
+///
+/// Provides an approximate indication of when user portfolio data
+/// (balance, orders, fills, positions) was last validated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserDataTimestampResponse {
+    /// Timestamp when user data was last updated (RFC3339).
+    pub as_of_time: String,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,6 +5,7 @@
 
 mod balance;
 mod common;
+mod exchange;
 mod fill;
 mod order;
 mod position;
@@ -13,6 +14,11 @@ pub(crate) mod query;
 // Re-export all public types
 pub use balance::BalanceResponse;
 pub use common::{Action, OrderStatus, OrderType, SelfTradePreventionType, Side, cents_to_dollars};
+pub use exchange::{
+    Announcement, AnnouncementStatus, AnnouncementType, ExchangeAnnouncementsResponse,
+    ExchangeSchedule, ExchangeScheduleResponse, ExchangeStatusResponse, MaintenanceWindow,
+    StandardHoursPeriod, TradingSession, UserDataTimestampResponse,
+};
 pub use fill::{Fill, FillsResponse, GetFillsParams};
 pub use order::{GetOrdersParams, Order, OrdersResponse};
 pub use position::{EventPosition, GetPositionsParams, MarketPosition, PositionsResponse};


### PR DESCRIPTION
## Summary
- Implements Exchange API endpoints following Kalshi docs
- Adds `get_exchange_status()`, `get_exchange_schedule()`, `get_exchange_announcements()`, and `get_user_data_timestamp()` methods to `KalshiClient`
- Creates all necessary types: `ExchangeStatusResponse`, `ExchangeScheduleResponse`, `ExchangeAnnouncementsResponse`, `UserDataTimestampResponse`, etc.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (43 tests)
- [ ] Manual testing against Kalshi demo API