### PR TITLE
docs: add WebSocket README and examples for remaining channels

### DIFF
--- a/examples/stream_lifecycle.rs
+++ b/examples/stream_lifecycle.rs
@@ -1,0 +1,188 @@
+//! Example: Stream lifecycle channels (MarketLifecycle, Multivariate).
+//!
+//! This example demonstrates subscribing to event-driven channels that track
+//! market state changes and multivariate collection updates.
+//!
+//! # Channels
+//!
+//! - `MarketLifecycle`: Market creation, activation, deactivation, determination, settlement
+//! - `Multivariate`: Multivariate collection lookup notifications
+//!
+//! # Usage
+//!
+//! ```bash
+//! KALSHI_API_KEY_ID=your_key KALSHI_PRIVATE_KEY_PATH=path/to/key.pem \
+//!     cargo run --example stream_lifecycle
+//! ```
+//!
+//! # Notes
+//!
+//! - These are public channels but events are infrequent
+//! - MarketLifecycle events occur when markets change state (open, close, settle)
+//! - Best tested during active market hours when new markets are created
+
+use std::time::Duration;
+use tokio::time::timeout;
+
+use kalshi_trade_rs::{
+    auth::KalshiConfig,
+    ws::{Channel, KalshiStreamClient, StreamMessage},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("kalshi_trade_rs=info".parse()?),
+        )
+        .init();
+
+    let config = KalshiConfig::from_env()?;
+    println!(
+        "Connecting to Kalshi {:?} environment...",
+        config.environment
+    );
+
+    let client = KalshiStreamClient::connect(&config).await?;
+    let mut handle = client.handle();
+    println!("Connected!\n");
+
+    // Collect all subscription IDs
+    let mut all_sids: Vec<i64> = Vec::new();
+
+    // MarketLifecycle requires market tickers, Multivariate does not
+    // We'll subscribe to them separately to handle this correctly
+
+    // First, subscribe to Multivariate (no tickers needed)
+    println!("Subscribing to Multivariate channel (all collections)...");
+    let mv_result = handle.subscribe(&[Channel::Multivariate], None).await?;
+
+    for sub in &mv_result.successful {
+        println!("  {} -> sid={}", sub.channel, sub.sid);
+    }
+    for err in &mv_result.failed {
+        println!(
+            "  {:?} FAILED: {} - {}",
+            err.channel, err.code, err.message
+        );
+    }
+    all_sids.extend(mv_result.sids());
+
+    // For MarketLifecycle, we need to specify market tickers
+    println!("\nSubscribing to MarketLifecycle channel...");
+
+    // MarketLifecycle requires tickers - fetch some active markets
+    let rest_client = kalshi_trade_rs::KalshiClient::new(config.clone())?;
+    let params = kalshi_trade_rs::GetMarketsParams::new()
+        .status(kalshi_trade_rs::MarketFilterStatus::Open)
+        .limit(5);
+    let markets = rest_client.get_markets_with_params(params).await?;
+
+    if markets.markets.is_empty() {
+        println!("  No active markets found - skipping MarketLifecycle subscription");
+    } else {
+        let tickers: Vec<&str> = markets.markets.iter().map(|m| m.ticker.as_str()).collect();
+        println!("  Subscribing to {} markets: {:?}", tickers.len(), tickers);
+
+        let lc_result = handle
+            .subscribe(&[Channel::MarketLifecycle], Some(&tickers))
+            .await?;
+
+        for sub in &lc_result.successful {
+            println!("  {} -> sid={}", sub.channel, sub.sid);
+        }
+        for err in &lc_result.failed {
+            println!(
+                "  {:?} FAILED: {} - {}",
+                err.channel, err.code, err.message
+            );
+        }
+        all_sids.extend(lc_result.sids());
+    }
+
+    if all_sids.is_empty() {
+        println!("\nNo channels subscribed successfully. Exiting.");
+        client.shutdown().await?;
+        return Ok(());
+    }
+
+    println!("\nWaiting for lifecycle events (120 seconds)...");
+    println!("Note: These events are infrequent - markets don't change state often\n");
+
+    let deadline = Duration::from_secs(120);
+    let start = std::time::Instant::now();
+
+    loop {
+        if start.elapsed() > deadline {
+            println!("\nReached time limit, shutting down...");
+            break;
+        }
+
+        match timeout(Duration::from_secs(30), handle.update_receiver.recv()).await {
+            Ok(Ok(update)) => match &update.msg {
+                StreamMessage::Closed { reason } => {
+                    println!("[CLOSED] {}", reason);
+                    break;
+                }
+                StreamMessage::ConnectionLost { reason } => {
+                    println!("[CONNECTION LOST] {}", reason);
+                    break;
+                }
+                StreamMessage::MarketLifecycle(lifecycle) => {
+                    println!(
+                        "[LIFECYCLE] {} | event={:?} | open={:?} | close={:?} | result={:?}",
+                        lifecycle.market_ticker,
+                        lifecycle.event_type,
+                        lifecycle.open_ts,
+                        lifecycle.close_ts,
+                        lifecycle.result
+                    );
+                    if let Some(meta) = &lifecycle.additional_metadata {
+                        println!(
+                            "            name={:?} | title={:?}",
+                            meta.name, meta.title
+                        );
+                    }
+                }
+                StreamMessage::Unsubscribed => {
+                    println!("[UNSUBSCRIBED] sid={}", update.sid);
+                }
+                _ => {
+                    // Multivariate and other updates
+                    println!(
+                        "[{}] sid={} | {:?}",
+                        update.channel.to_uppercase(),
+                        update.sid,
+                        update.msg
+                    );
+                }
+            },
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(n))) => {
+                println!("[WARN] Dropped {} messages (slow consumer)", n);
+            }
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                println!("[ERROR] Channel closed");
+                break;
+            }
+            Err(_) => {
+                println!(
+                    "[INFO] No lifecycle events in last 30 seconds (this is normal)..."
+                );
+            }
+        }
+    }
+
+    println!("Unsubscribing...");
+    if !all_sids.is_empty() {
+        handle.unsubscribe(&all_sids).await?;
+    }
+
+    println!("Shutting down...");
+    client.shutdown().await?;
+
+    println!("Done!");
+    Ok(())
+}

--- a/examples/stream_user_channels.rs
+++ b/examples/stream_user_channels.rs
@@ -1,0 +1,162 @@
+//! Example: Stream user-scoped channels (Fill, MarketPositions, Communications).
+//!
+//! This example demonstrates subscribing to authenticated channels that track
+//! user-specific activity. These channels don't require market tickers - they
+//! automatically receive all events for the authenticated user.
+//!
+//! # Channels
+//!
+//! - `Fill`: Notifications when your orders are filled
+//! - `MarketPositions`: Real-time position updates
+//! - `Communications`: RFQ and quote notifications
+//!
+//! # Usage
+//!
+//! ```bash
+//! KALSHI_API_KEY_ID=your_key KALSHI_PRIVATE_KEY_PATH=path/to/key.pem \
+//!     cargo run --example stream_user_channels
+//! ```
+//!
+//! # Notes
+//!
+//! - These channels require valid API credentials
+//! - You'll only see updates when there's actual activity (fills, position changes, etc.)
+//! - For testing fills, run the `trading.rs` example in another terminal
+
+use std::time::Duration;
+use tokio::time::timeout;
+
+use kalshi_trade_rs::{
+    auth::KalshiConfig,
+    ws::{Channel, KalshiStreamClient, StreamMessage},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("kalshi_trade_rs=debug".parse()?),
+        )
+        .init();
+
+    let config = KalshiConfig::from_env()?;
+    println!(
+        "Connecting to Kalshi {:?} environment...",
+        config.environment
+    );
+
+    let client = KalshiStreamClient::connect(&config).await?;
+    let mut handle = client.handle();
+    println!("Connected!\n");
+
+    // Subscribe to all user-scoped channels
+    // These don't require market tickers - they receive all user events
+    let channels = [
+        Channel::Fill,
+        Channel::MarketPositions,
+        Channel::Communications,
+    ];
+
+    println!(
+        "Subscribing to {} user channels: {:?}",
+        channels.len(),
+        channels.iter().map(|c| c.as_str()).collect::<Vec<_>>()
+    );
+
+    let result = handle.subscribe(&channels, None).await?;
+
+    println!("\nSubscription results:");
+    for sub in &result.successful {
+        println!("  {} -> sid={}", sub.channel, sub.sid);
+    }
+    for err in &result.failed {
+        println!(
+            "  {:?} FAILED: {} - {}",
+            err.channel, err.code, err.message
+        );
+    }
+
+    if result.successful.is_empty() {
+        println!("\nNo channels subscribed successfully. Exiting.");
+        client.shutdown().await?;
+        return Ok(());
+    }
+
+    println!("\nWaiting for updates (60 seconds)...");
+    println!("Tip: Create/fill orders in another terminal to see Fill updates\n");
+
+    let deadline = Duration::from_secs(60);
+    let start = std::time::Instant::now();
+
+    loop {
+        if start.elapsed() > deadline {
+            println!("\nReached time limit, shutting down...");
+            break;
+        }
+
+        match timeout(Duration::from_secs(10), handle.update_receiver.recv()).await {
+            Ok(Ok(update)) => match &update.msg {
+                StreamMessage::Closed { reason } => {
+                    println!("[CLOSED] {}", reason);
+                    break;
+                }
+                StreamMessage::ConnectionLost { reason } => {
+                    println!("[CONNECTION LOST] {}", reason);
+                    break;
+                }
+                StreamMessage::Fill(fill) => {
+                    println!(
+                        "[FILL] {} | order={} | {} {} @ {}c | {} contracts | taker={}",
+                        fill.market_ticker,
+                        fill.order_id,
+                        format!("{:?}", fill.action).to_uppercase(),
+                        format!("{:?}", fill.side).to_uppercase(),
+                        fill.yes_price,
+                        fill.count,
+                        fill.is_taker
+                    );
+                }
+                StreamMessage::MarketPosition(pos) => {
+                    println!(
+                        "[POSITION] {} | position={:?} | cost={:?} | pnl={:?}",
+                        pos.market_ticker.as_deref().unwrap_or("?"),
+                        pos.position,
+                        pos.position_cost,
+                        pos.realized_pnl
+                    );
+                }
+                StreamMessage::Communication(comm) => {
+                    println!("[COMMUNICATION] {:?}", comm);
+                }
+                StreamMessage::Unsubscribed => {
+                    println!("[UNSUBSCRIBED] sid={}", update.sid);
+                }
+                _ => {
+                    println!("[OTHER] channel={} sid={}", update.channel, update.sid);
+                }
+            },
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(n))) => {
+                println!("[WARN] Dropped {} messages (slow consumer)", n);
+            }
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                println!("[ERROR] Channel closed");
+                break;
+            }
+            Err(_) => {
+                println!("[INFO] No updates in last 10 seconds (waiting for activity)...");
+            }
+        }
+    }
+
+    println!("Unsubscribing...");
+    handle.unsubscribe(&result.sids()).await?;
+
+    println!("Shutting down...");
+    client.shutdown().await?;
+
+    println!("Done!");
+    Ok(())
+}

--- a/src/ws/README.md
+++ b/src/ws/README.md
@@ -1,0 +1,340 @@
+# Kalshi WebSocket Implementation Status
+
+Comprehensive tracking of Kalshi WebSocket channels: implementation status, verification status, and gaps.
+
+**Last updated**: 2026-01-11
+**Reference**: [Official Kalshi WebSocket Documentation](https://docs.kalshi.com/reference/websocket-overview)
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Implemented and verified working |
+| ⚠️ | Implemented with caveats (see notes) |
+| 🔲 | Implemented but not yet verified |
+| ❌ | Not implemented |
+
+---
+
+## Summary
+
+| Category | Implemented | Total | Coverage |
+|----------|-------------|-------|----------|
+| Public Channels | 4 | 4 | 100% |
+| Authenticated Channels | 3 | 3 | 100% |
+| Lifecycle Channels | 1 | 1 | 100% |
+| **TOTAL** | **8** | **8** | **100%** |
+
+---
+
+## Connection Details
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| RSA-PSS Authentication | ✅ | Headers: KALSHI-ACCESS-KEY, KALSHI-ACCESS-SIGNATURE, KALSHI-ACCESS-TIMESTAMP |
+| Connection Strategies | ✅ | `Simple` (fast-fail) and `Retry` (exponential backoff) |
+| Health Monitoring | ✅ | Bidirectional ping/pong with configurable timeouts |
+| Heartbeat Response | ✅ | Auto-responds to Kalshi's 10-second ping frames |
+| Graceful Shutdown | ✅ | Clean close with subscriber notification |
+| Reconnection Support | ✅ | Via application-level pattern (see examples) |
+
+---
+
+## Public Channels
+
+| Status | Channel | Rust Type | Message Types | Notes |
+|--------|---------|-----------|---------------|-------|
+| ✅ | `orderbook_delta` | `Channel::OrderbookDelta` | `OrderbookSnapshotData`, `OrderbookDeltaData` | Sends snapshot first, then deltas |
+| ✅ | `ticker` | `Channel::Ticker` | `TickerData` | Price, volume, open interest updates |
+| ✅ | `trade` | `Channel::Trade` | `TradeData` | Public trade notifications |
+| 🔲 | `market_lifecycle_v2` | `Channel::MarketLifecycle` | `MarketLifecycleData` | Market state changes |
+
+**Source file**: `src/ws/channel.rs`
+
+---
+
+## Authenticated Channels
+
+These channels require valid API credentials to subscribe.
+
+| Status | Channel | Rust Type | Message Types | Notes |
+|--------|---------|-----------|---------------|-------|
+| 🔲 | `fill` | `Channel::Fill` | `FillData` | User order fill notifications |
+| 🔲 | `market_positions` | `Channel::MarketPositions` | `MarketPositionData` | Real-time position updates |
+| 🔲 | `communications` | `Channel::Communications` | `CommunicationData` | RFQ and quote notifications |
+
+**Source file**: `src/ws/channel.rs`
+
+---
+
+## Other Channels
+
+| Status | Channel | Rust Type | Notes |
+|--------|---------|-----------|-------|
+| 🔲 | `multivariate` | `Channel::Multivariate` | Multivariate collection lookup notifications |
+
+---
+
+## Message Types
+
+All message types are defined in `src/ws/message.rs`:
+
+| Type | Description | Fields |
+|------|-------------|--------|
+| `StreamUpdate` | Wrapper for all updates | `channel`, `sid`, `seq`, `msg` |
+| `StreamMessage` | Enum of all message variants | See below |
+| `OrderbookSnapshotData` | Full orderbook state | `market_ticker`, `yes`, `no`, dollar variants |
+| `OrderbookDeltaData` | Incremental orderbook update | `market_ticker`, `price`, `delta`, `side` |
+| `TickerData` | Market ticker data | `market_ticker`, `price`, `yes_bid`, `yes_ask`, `volume`, `open_interest`, etc. |
+| `TradeData` | Public trade info | `market_ticker`, `yes_price`, `no_price`, `count`, `taker_side`, `ts` |
+| `FillData` | User fill notification | `trade_id`, `order_id`, `market_ticker`, `is_taker`, `side`, `yes_price`, `count`, etc. |
+| `MarketPositionData` | Position update | `user_id`, `market_ticker`, `position`, `position_cost`, `realized_pnl`, etc. |
+| `MarketLifecycleData` | Lifecycle event | `event_type`, `market_ticker`, timestamps, `result`, `additional_metadata` |
+| `CommunicationData` | RFQ/Quote events | Tagged enum: `RfqCreated`, `RfqDeleted`, `QuoteCreated`, `QuoteAccepted` |
+
+### System Messages
+
+These are locally-generated, not from the server:
+
+| Type | Description | When Sent |
+|------|-------------|-----------|
+| `StreamMessage::Closed` | Clean connection close | User-requested or server close frame |
+| `StreamMessage::ConnectionLost` | Unexpected disconnection | Error, timeout, network failure |
+| `StreamMessage::Unsubscribed` | Channel unsubscribed | After successful unsubscribe |
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         User Code                               │
+│  ┌──────────────────┐    ┌──────────────────┐                   │
+│  │ KalshiStreamClient│    │ KalshiStreamHandle│  (cloneable)     │
+│  └────────┬─────────┘    └────────┬─────────┘                   │
+│           │ owns                  │ clone                        │
+└───────────┼───────────────────────┼─────────────────────────────┘
+            │                       │
+            ▼                       ▼
+┌───────────────────────────────────────────────────────────────────┐
+│                     KalshiStreamSession (Actor)                   │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐   │
+│  │ cmd_receiver│◄─┤ Commands    │  │ update_sender (broadcast)│   │
+│  │   (mpsc)    │  │ Subscribe   │  │   → all handles          │   │
+│  └─────────────┘  │ Unsubscribe │  └─────────────────────────┘   │
+│                   │ Close       │                                 │
+│                   └─────────────┘                                 │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │                    WebSocket Connection                      │ │
+│  │  ┌──────────────┐              ┌──────────────┐             │ │
+│  │  │  ws_writer   │ ◄──────────► │  ws_reader   │             │ │
+│  │  │  (SplitSink) │              │ (SplitStream)│             │ │
+│  │  └──────────────┘              └──────────────┘             │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │                    Request Handler                           │ │
+│  │  pending: HashMap<request_id, oneshot::Sender>               │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Module Structure
+
+| File | Purpose |
+|------|---------|
+| `mod.rs` (ws.rs) | Module re-exports, `ConnectStrategy`, `HealthConfig` |
+| `channel.rs` | `Channel` enum with auth/ticker requirements |
+| `client.rs` | `KalshiStreamClient`, `KalshiStreamHandle` |
+| `command.rs` | `StreamCommand`, `SubscribeResult` |
+| `message.rs` | All message/data types |
+| `protocol.rs` | JSON serialization, `IncomingMessage` parsing |
+| `request_handler.rs` | Request ID → response mapping |
+| `session.rs` | Actor implementation, connection lifecycle |
+
+---
+
+## Test Coverage
+
+### Unit Tests
+
+| File | Tests | Status |
+|------|-------|--------|
+| `protocol.rs` | Subscribe/unsubscribe message building, response parsing | ✅ |
+| `message.rs` | Side/Action serialization, message deserialization | ✅ |
+| `request_handler.rs` | Register/handle/cancel request flow | ✅ |
+| `session.rs` | SID extraction from responses | ✅ |
+| `client.rs` | Handle cloning, broadcast receiver behavior | ✅ |
+
+### Example Programs (Integration Tests)
+
+| Example | Channels Tested | Status |
+|---------|-----------------|--------|
+| `stream_ticker.rs` | Ticker, Trade | ✅ Verified |
+| `stream_reconnect.rs` | Ticker (with reconnection pattern) | ✅ Verified |
+| `multi_channel_subscribe.rs` | Ticker, Trade, OrderbookDelta | ✅ Verified |
+| `stream_user_channels.rs` | Fill, MarketPositions, Communications | 🔲 Needs activity |
+| `stream_lifecycle.rs` | MarketLifecycle, Multivariate | 🔲 Needs activity |
+
+### Notes on Verification
+
+Some channels require specific conditions to produce updates:
+
+- **Fill**: Requires placing orders that get matched/filled
+- **MarketPositions**: Requires having active positions in markets
+- **Communications**: Requires RFQ/quote activity (typically institutional)
+- **MarketLifecycle**: Events are infrequent (market opens, closes, settlements)
+- **Multivariate**: Requires multivariate collection lookup activity
+
+---
+
+## Usage Examples
+
+### Basic Connection
+
+```rust
+use kalshi_trade_rs::auth::KalshiConfig;
+use kalshi_trade_rs::ws::{Channel, KalshiStreamClient};
+
+let config = KalshiConfig::from_env()?;
+let client = KalshiStreamClient::connect(&config).await?;
+let mut handle = client.handle();
+
+// Subscribe to ticker updates for specific markets
+let result = handle.subscribe(
+    &[Channel::Ticker],
+    Some(&["INXD-25JAN17-B5955"]),
+).await?;
+
+// Process updates
+while let Ok(update) = handle.update_receiver.recv().await {
+    println!("{:?}", update.msg);
+}
+```
+
+### Production Reconnection Pattern
+
+```rust
+use kalshi_trade_rs::ws::{ConnectStrategy, KalshiStreamClient, StreamMessage};
+
+let client = KalshiStreamClient::connect_with_strategy(
+    &config,
+    ConnectStrategy::Retry, // Retries with exponential backoff
+).await?;
+
+let mut handle = client.handle();
+
+loop {
+    match handle.update_receiver.recv().await {
+        Ok(update) => match &update.msg {
+            StreamMessage::ConnectionLost { reason } => {
+                // Reconnect logic here
+                break;
+            }
+            _ => { /* process update */ }
+        },
+        Err(_) => break,
+    }
+}
+```
+
+### Multi-Channel Subscription
+
+```rust
+let result = handle.subscribe(
+    &[Channel::Ticker, Channel::Trade, Channel::OrderbookDelta],
+    Some(&["AAPL-25JAN17"]),
+).await?;
+
+// Check results
+println!("Subscribed to {} channels", result.successful.len());
+for sub in &result.successful {
+    println!("  {} → sid={}", sub.channel, sub.sid);
+}
+```
+
+---
+
+## Protocol Details
+
+### Subscribe Request Format
+
+```json
+{
+    "id": 1,
+    "cmd": "subscribe",
+    "params": {
+        "channels": ["ticker", "trade"],
+        "market_ticker": "INXD-25JAN17-B5955"
+    }
+}
+```
+
+### Unsubscribe Request Format
+
+```json
+{
+    "id": 2,
+    "cmd": "unsubscribe",
+    "params": {
+        "sids": [123, 456]
+    }
+}
+```
+
+### Response Format
+
+```json
+{
+    "id": 1,
+    "type": "subscribed",
+    "msg": {
+        "channel": "ticker",
+        "sid": 123
+    }
+}
+```
+
+### Update Format
+
+```json
+{
+    "type": "ticker",
+    "sid": 123,
+    "seq": 42,
+    "msg": {
+        "market_ticker": "INXD-25JAN17-B5955",
+        "price": 65,
+        "yes_bid": 64,
+        "yes_ask": 66,
+        "volume": 1000,
+        "open_interest": 500,
+        "dollar_volume": 65000,
+        "dollar_open_interest": 32500,
+        "ts": 1704067200
+    }
+}
+```
+
+---
+
+## Known Issues & Caveats
+
+1. **Market ticker requirements**: Channels `orderbook_delta`, `ticker`, `trade`, and `market_lifecycle_v2` require at least one market ticker. The client validates this before sending.
+
+2. **Authentication-only channels**: `fill`, `market_positions`, and `communications` are user-scoped and don't require/use market tickers.
+
+3. **Broadcast channel lag**: If a subscriber falls behind, they will receive a `RecvError::Lagged(n)` indicating dropped messages. Increase `buffer_size` via `connect_with_options()` if needed.
+
+4. **Multi-channel responses**: When subscribing to N channels, Kalshi sends N separate responses (all with the same request ID but different SIDs). The implementation collects all responses before returning.
+
+---
+
+## References
+
+- [Kalshi WebSocket Overview](https://docs.kalshi.com/reference/websocket-overview)
+- [Kalshi WebSocket Subscriptions](https://docs.kalshi.com/reference/ws-subscriptions)
+- Example programs: `examples/stream_ticker.rs`, `examples/stream_reconnect.rs`, `examples/multi_channel_subscribe.rs`


### PR DESCRIPTION
## Summary

- Add comprehensive `src/ws/README.md` documenting implementation status, architecture, protocol details
- Add `examples/stream_user_channels.rs` covering Fill, MarketPositions, Communications channels
- Add `examples/stream_lifecycle.rs` covering MarketLifecycle, Multivariate channels

All 8 WebSocket channels now have example coverage.

## Channel Coverage

| Example | Channels |
|---------|----------|
| `stream_ticker.rs` | Ticker, Trade |
| `stream_reconnect.rs` | Ticker |
| `multi_channel_subscribe.rs` | Ticker, Trade, OrderbookDelta |
| **`stream_user_channels.rs`** (new) | Fill, MarketPositions, Communications |
| **`stream_lifecycle.rs`** (new) | MarketLifecycle, Multivariate |

## Test plan

- [x] `cargo check --example stream_user_channels --example stream_lifecycle` passes
- [ ] Run examples against demo environment to verify subscription works