### PR TITLE
fix: update model structs to match actual API responses

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -39,11 +39,11 @@ pub use communications::{
     ListRfqsResponse, Quote, QuoteResponse, Rfq, RfqResponse,
 };
 pub use event::{
-    Event, EventCandlesticksResponse, EventForecastPercentileHistoryResponse, EventMetadataResponse,
-    EventResponse, EventStatus, EventsResponse, ForecastHistoryPoint, ForecastPeriod,
-    GetEventCandlesticksParams, GetEventForecastPercentileHistoryParams, GetEventParams,
-    GetEventsParams, GetMultivariateEventsParams, MarketDetail, Milestone,
-    MultivariateEventsResponse, PercentilePoint, SettlementSource, MAX_FORECAST_PERCENTILES,
+    Event, EventCandlesticksResponse, EventForecastPercentileHistoryResponse,
+    EventMetadataResponse, EventResponse, EventStatus, EventsResponse, ForecastHistoryPoint,
+    ForecastPeriod, GetEventCandlesticksParams, GetEventForecastPercentileHistoryParams,
+    GetEventParams, GetEventsParams, GetMultivariateEventsParams, MAX_FORECAST_PERCENTILES,
+    MarketDetail, Milestone, MultivariateEventsResponse, PercentilePoint, SettlementSource,
 };
 pub use exchange::{
     Announcement, AnnouncementStatus, AnnouncementType, ExchangeAnnouncementsResponse,
@@ -52,10 +52,10 @@ pub use exchange::{
 };
 pub use fcm::{GetFcmOrdersParams, GetFcmPositionsParams, SettlementStatus};
 pub use fill::{Fill, FillsResponse, GetFillsParams};
-pub use incentive_program::{GetIncentiveProgramsParams, IncentiveProgram, IncentiveProgramsResponse};
-pub use live_data::{
-    BatchLiveDataResponse, GetBatchLiveDataParams, LiveData, LiveDataResponse,
+pub use incentive_program::{
+    GetIncentiveProgramsParams, IncentiveProgram, IncentiveProgramsResponse,
 };
+pub use live_data::{BatchLiveDataResponse, GetBatchLiveDataParams, LiveData, LiveDataResponse};
 pub use market::{
     BatchCandlesticksResponse, Candlestick, CandlestickPeriod, CandlesticksResponse,
     GetBatchCandlesticksParams, GetCandlesticksParams, GetMarketsParams, GetOrderbookParams,
@@ -64,9 +64,7 @@ pub use market::{
     OrderbookResponse, PriceLevelDollars, PriceOhlcData, PriceRange, StrikeType, TakerSide, Trade,
     TradesResponse,
 };
-pub use milestone::{
-    GetMilestonesParams, MilestoneInfo, MilestoneResponse, MilestonesResponse,
-};
+pub use milestone::{GetMilestonesParams, MilestoneInfo, MilestoneResponse, MilestonesResponse};
 pub use multivariate::{
     CollectionVariable, CreateMarketInCollectionRequest, CreateMarketInCollectionResponse,
     GetLookupHistoryParams, GetMultivariateCollectionsParams, LookupHistoryEntry,

--- a/src/models/communications.rs
+++ b/src/models/communications.rs
@@ -2,8 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::market::MveSelectedLeg;
 use super::Side;
+use super::market::MveSelectedLeg;
 
 /// Request body for POST /communications/rfqs (create RFQ).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +83,9 @@ impl CreateRfqRequest {
         rest_remainder: bool,
     ) -> crate::error::Result<Self> {
         if target_cost_centi_cents <= 0 {
-            return Err(crate::error::Error::InvalidTargetCost(target_cost_centi_cents));
+            return Err(crate::error::Error::InvalidTargetCost(
+                target_cost_centi_cents,
+            ));
         }
         Ok(Self {
             market_ticker: market_ticker.into(),
@@ -129,7 +131,9 @@ impl CreateRfqRequest {
         rest_remainder: bool,
     ) -> crate::error::Result<Self> {
         if target_cost_dollars <= 0.0 {
-            return Err(crate::error::Error::InvalidTargetCostDollars(target_cost_dollars));
+            return Err(crate::error::Error::InvalidTargetCostDollars(
+                target_cost_dollars,
+            ));
         }
         let centi_cents = (target_cost_dollars * 10000.0).round() as i64;
         Ok(Self {
@@ -222,7 +226,11 @@ impl CreateQuoteRequest {
     /// # Errors
     ///
     /// Returns an error if `yes_price_cents` is not between 1 and 99.
-    pub fn try_from_cents(rfq_id: impl Into<String>, yes_price_cents: i64, rest_remainder: bool) -> crate::error::Result<Self> {
+    pub fn try_from_cents(
+        rfq_id: impl Into<String>,
+        yes_price_cents: i64,
+        rest_remainder: bool,
+    ) -> crate::error::Result<Self> {
         if !(1..=99).contains(&yes_price_cents) {
             return Err(crate::error::Error::InvalidPrice(yes_price_cents));
         }
@@ -249,9 +257,12 @@ impl CreateQuoteRequest {
     ///
     /// Panics if `yes_price_cents` is not between 1 and 99.
     #[must_use]
-    pub fn from_cents(rfq_id: impl Into<String>, yes_price_cents: i64, rest_remainder: bool) -> Self {
-        Self::try_from_cents(rfq_id, yes_price_cents, rest_remainder)
-            .expect("invalid quote price")
+    pub fn from_cents(
+        rfq_id: impl Into<String>,
+        yes_price_cents: i64,
+        rest_remainder: bool,
+    ) -> Self {
+        Self::try_from_cents(rfq_id, yes_price_cents, rest_remainder).expect("invalid quote price")
     }
 }
 
@@ -479,7 +490,10 @@ impl ListQuotesParams {
         qb.push_opt("status", self.status.as_ref());
         qb.push_opt("quote_creator_user_id", self.quote_creator_user_id.as_ref());
         qb.push_opt("rfq_creator_user_id", self.rfq_creator_user_id.as_ref());
-        qb.push_opt("rfq_creator_subtrader_id", self.rfq_creator_subtrader_id.as_ref());
+        qb.push_opt(
+            "rfq_creator_subtrader_id",
+            self.rfq_creator_subtrader_id.as_ref(),
+        );
         qb.push_opt("rfq_id", self.rfq_id.as_ref());
         qb.build()
     }
@@ -545,8 +559,7 @@ impl Rfq {
     /// Returns the target cost in dollars, if available.
     #[must_use]
     pub fn target_cost_dollars(&self) -> Option<f64> {
-        self.target_cost_centi_cents
-            .map(|cc| cc as f64 / 10000.0)
+        self.target_cost_centi_cents.map(|cc| cc as f64 / 10000.0)
     }
 }
 

--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -435,7 +435,11 @@ impl GetEventCandlesticksParams {
     /// Panics if `start_ts >= end_ts`.
     /// Use [`try_new`](Self::try_new) for fallible construction.
     #[must_use]
-    pub fn new(start_ts: i64, end_ts: i64, period_interval: super::market::CandlestickPeriod) -> Self {
+    pub fn new(
+        start_ts: i64,
+        end_ts: i64,
+        period_interval: super::market::CandlestickPeriod,
+    ) -> Self {
         Self::try_new(start_ts, end_ts, period_interval)
             .expect("invalid event candlestick parameters")
     }

--- a/src/models/fcm.rs
+++ b/src/models/fcm.rs
@@ -289,7 +289,10 @@ impl GetFcmPositionsParams {
         qb.push_opt("ticker", self.ticker.as_ref());
         qb.push_opt("event_ticker", self.event_ticker.as_ref());
         qb.push_opt("count_filter", self.count_filter.as_ref());
-        qb.push_opt("settlement_status", self.settlement_status.map(|s| s.as_str()));
+        qb.push_opt(
+            "settlement_status",
+            self.settlement_status.map(|s| s.as_str()),
+        );
         qb.push_opt("limit", self.limit);
         qb.push_opt("cursor", self.cursor.as_ref());
         qb.build()
@@ -303,10 +306,7 @@ mod tests {
     #[test]
     fn test_fcm_orders_params_required_only() {
         let params = GetFcmOrdersParams::new("subtrader-123");
-        assert_eq!(
-            params.to_query_string(),
-            "?subtrader_id=subtrader-123"
-        );
+        assert_eq!(params.to_query_string(), "?subtrader_id=subtrader-123");
     }
 
     #[test]
@@ -325,10 +325,7 @@ mod tests {
     #[test]
     fn test_fcm_positions_params_required_only() {
         let params = GetFcmPositionsParams::new("subtrader-456");
-        assert_eq!(
-            params.to_query_string(),
-            "?subtrader_id=subtrader-456"
-        );
+        assert_eq!(params.to_query_string(), "?subtrader_id=subtrader-456");
     }
 
     #[test]

--- a/src/models/incentive_program.rs
+++ b/src/models/incentive_program.rs
@@ -12,36 +12,30 @@ pub struct IncentiveProgram {
     /// The unique identifier for the incentive program.
     #[serde(default)]
     pub id: Option<String>,
-    /// The name of the incentive program.
+    /// The incentive type (e.g., "volume", "liquidity").
     #[serde(default)]
-    pub name: Option<String>,
-    /// A description of the incentive program.
+    pub incentive_type: Option<String>,
+    /// The associated market ticker.
     #[serde(default)]
-    pub description: Option<String>,
+    pub market_ticker: Option<String>,
     /// The start date of the incentive program (RFC3339 timestamp).
     #[serde(default)]
     pub start_date: Option<String>,
     /// The end date of the incentive program (RFC3339 timestamp).
     #[serde(default)]
     pub end_date: Option<String>,
-    /// The status of the incentive program.
+    /// The reward amount for the period (in cents).
     #[serde(default)]
-    pub status: Option<String>,
-    /// The associated series tickers.
+    pub period_reward: Option<i64>,
+    /// Discount factor in basis points.
     #[serde(default)]
-    pub series_tickers: Option<Vec<String>>,
-    /// The associated event tickers.
+    pub discount_factor_bps: Option<i64>,
+    /// Whether the program has been paid out.
     #[serde(default)]
-    pub event_tickers: Option<Vec<String>>,
-    /// The associated market tickers.
+    pub paid_out: Option<bool>,
+    /// Target size for the program.
     #[serde(default)]
-    pub market_tickers: Option<Vec<String>>,
-    /// The reward type (e.g., "volume_rebate", "maker_taker").
-    #[serde(default)]
-    pub reward_type: Option<String>,
-    /// Additional program details/configuration.
-    #[serde(default)]
-    pub details: Option<serde_json::Value>,
+    pub target_size: Option<i64>,
 }
 
 /// Response from GET /incentive_programs.
@@ -51,7 +45,7 @@ pub struct IncentiveProgramsResponse {
     pub incentive_programs: Vec<IncentiveProgram>,
     /// Cursor for pagination.
     #[serde(default)]
-    pub cursor: Option<String>,
+    pub next_cursor: Option<String>,
 }
 
 /// Query parameters for GET /incentive_programs.
@@ -139,12 +133,16 @@ mod tests {
         let json = r#"{
             "incentive_programs": [{
                 "id": "prog_123",
-                "name": "Maker Rewards",
-                "status": "active"
+                "incentive_type": "volume",
+                "market_ticker": "KXTEST",
+                "period_reward": 1000000
             }]
         }"#;
         let response: IncentiveProgramsResponse = serde_json::from_str(json).unwrap();
         assert_eq!(response.incentive_programs.len(), 1);
-        assert_eq!(response.incentive_programs[0].id, Some("prog_123".to_string()));
+        assert_eq!(
+            response.incentive_programs[0].id,
+            Some("prog_123".to_string())
+        );
     }
 }

--- a/src/models/market.rs
+++ b/src/models/market.rs
@@ -850,8 +850,7 @@ impl GetCandlesticksParams {
     /// Use [`try_new`](Self::try_new) for fallible construction.
     #[must_use]
     pub fn new(start_ts: i64, end_ts: i64, period_interval: CandlestickPeriod) -> Self {
-        Self::try_new(start_ts, end_ts, period_interval)
-            .expect("invalid candlestick parameters")
+        Self::try_new(start_ts, end_ts, period_interval).expect("invalid candlestick parameters")
     }
 
     /// Create new candlesticks query parameters with validation.

--- a/src/models/milestone.rs
+++ b/src/models/milestone.rs
@@ -11,40 +11,40 @@ use crate::models::query::QueryBuilder;
 pub struct MilestoneInfo {
     /// The unique milestone identifier.
     #[serde(default)]
-    pub milestone_id: Option<String>,
-    /// The milestone type (e.g., "price", "score").
-    #[serde(default)]
+    pub id: Option<String>,
+    /// The milestone type (e.g., "basketball_game", "one_off_milestone").
+    #[serde(default, rename = "type")]
     pub milestone_type: Option<String>,
     /// The title or name of the milestone.
     #[serde(default)]
     pub title: Option<String>,
-    /// The description of the milestone.
+    /// The category (e.g., "Sports", "sports").
     #[serde(default)]
-    pub description: Option<String>,
-    /// The start timestamp (RFC3339 or Unix).
+    pub category: Option<String>,
+    /// Notification message for the milestone.
     #[serde(default)]
-    pub start_ts: Option<String>,
-    /// The end timestamp (RFC3339 or Unix).
+    pub notification_message: Option<String>,
+    /// The start date (RFC3339 timestamp).
     #[serde(default)]
-    pub end_ts: Option<String>,
-    /// The associated series ticker.
+    pub start_date: Option<String>,
+    /// The end date (RFC3339 timestamp).
     #[serde(default)]
-    pub series_ticker: Option<String>,
-    /// The associated event ticker.
+    pub end_date: Option<String>,
+    /// Primary event tickers associated with this milestone.
     #[serde(default)]
-    pub event_ticker: Option<String>,
-    /// The current value.
+    pub primary_event_tickers: Option<Vec<String>>,
+    /// Related event tickers.
     #[serde(default)]
-    pub value: Option<f64>,
-    /// The value as a string.
+    pub related_event_tickers: Option<Vec<String>>,
+    /// The source identifier.
     #[serde(default)]
-    pub value_string: Option<String>,
-    /// Last update timestamp.
+    pub source_id: Option<String>,
+    /// Last update timestamp (RFC3339).
     #[serde(default)]
-    pub updated_ts: Option<i64>,
-    /// Additional milestone metadata.
+    pub last_updated_ts: Option<String>,
+    /// Additional milestone details.
     #[serde(default)]
-    pub metadata: Option<serde_json::Value>,
+    pub details: Option<serde_json::Value>,
 }
 
 /// Query parameters for GET /milestones.

--- a/src/models/multivariate.rs
+++ b/src/models/multivariate.rs
@@ -148,7 +148,11 @@ impl CreateMarketInCollectionRequest {
 
     /// Add a variable value.
     #[must_use]
-    pub fn variable(mut self, name: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+    pub fn variable(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
         self.variables.insert(name.into(), value.into());
         self
     }
@@ -191,7 +195,11 @@ impl LookupTickersRequest {
 
     /// Add a variable value for lookup.
     #[must_use]
-    pub fn variable(mut self, name: impl Into<String>, value: impl Into<serde_json::Value>) -> Self {
+    pub fn variable(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
         self.variables.insert(name.into(), value.into());
         self
     }

--- a/src/models/order.rs
+++ b/src/models/order.rs
@@ -722,7 +722,9 @@ pub struct QueuePosition {
 /// Response from GET /portfolio/orders/queue_positions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueuePositionsResponse {
-    pub queue_positions: Vec<QueuePosition>,
+    /// Queue positions (may be null if no orders have queue positions).
+    #[serde(default)]
+    pub queue_positions: Option<Vec<QueuePosition>>,
 }
 
 /// Response from GET /portfolio/orders/{order_id}/queue_position.

--- a/src/models/order_group.rs
+++ b/src/models/order_group.rs
@@ -136,9 +136,7 @@ mod tests {
         let params = GetOrderGroupsParams::new().limit(50);
         assert!(params.to_query_string().contains("limit=50"));
 
-        let params = GetOrderGroupsParams::new()
-            .cursor("abc123")
-            .limit(25);
+        let params = GetOrderGroupsParams::new().cursor("abc123").limit(25);
         let qs = params.to_query_string();
         assert!(qs.contains("cursor=abc123"));
         assert!(qs.contains("limit=25"));

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -10,7 +10,8 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TagsByCategoriesResponse {
     /// Mapping of series categories to their associated tags.
-    pub tags_by_categories: HashMap<String, Vec<String>>,
+    /// Some categories may have null/empty tags.
+    pub tags_by_categories: HashMap<String, Option<Vec<String>>>,
 }
 
 /// Competition filter details within a sport.
@@ -55,12 +56,20 @@ mod tests {
         let json = r#"{
             "tags_by_categories": {
                 "Politics": ["US Elections", "Congress", "Presidential"],
-                "Sports": ["NFL", "NBA", "MLB"]
+                "Sports": ["NFL", "NBA", "MLB"],
+                "Empty": null
             }
         }"#;
         let response: TagsByCategoriesResponse = serde_json::from_str(json).unwrap();
         assert!(response.tags_by_categories.contains_key("Politics"));
-        assert_eq!(response.tags_by_categories["Sports"].len(), 3);
+        assert_eq!(
+            response.tags_by_categories["Sports"]
+                .as_ref()
+                .unwrap()
+                .len(),
+            3
+        );
+        assert!(response.tags_by_categories["Empty"].is_none());
     }
 
     #[test]

--- a/src/models/settlement.rs
+++ b/src/models/settlement.rs
@@ -101,7 +101,8 @@ impl GetSettlementsParams {
     /// Use [`try_event_ticker`](Self::try_event_ticker) for fallible construction.
     #[must_use]
     pub fn event_ticker(self, event_ticker: impl Into<String>) -> Self {
-        self.try_event_ticker(event_ticker).expect("too many event tickers")
+        self.try_event_ticker(event_ticker)
+            .expect("too many event tickers")
     }
 
     /// Filter by event ticker with validation (comma-separated for multiple, max 10).

--- a/src/models/structured_target.rs
+++ b/src/models/structured_target.rs
@@ -11,37 +11,22 @@ use crate::models::query::QueryBuilder;
 pub struct StructuredTarget {
     /// The unique identifier for the structured target.
     #[serde(default)]
-    pub structured_target_id: Option<String>,
-    /// The title or name.
+    pub id: Option<String>,
+    /// The name of the structured target.
     #[serde(default)]
-    pub title: Option<String>,
-    /// The description.
-    #[serde(default)]
-    pub description: Option<String>,
-    /// The target type.
-    #[serde(default)]
+    pub name: Option<String>,
+    /// The target type (e.g., "ufc_competitor", "soccer_team", "basketball_team").
+    #[serde(default, rename = "type")]
     pub target_type: Option<String>,
-    /// The associated series ticker.
+    /// The source identifier.
     #[serde(default)]
-    pub series_ticker: Option<String>,
-    /// The associated event ticker.
+    pub source_id: Option<String>,
+    /// Additional details/configuration.
     #[serde(default)]
-    pub event_ticker: Option<String>,
-    /// The target value.
+    pub details: Option<serde_json::Value>,
+    /// Last update timestamp (RFC3339).
     #[serde(default)]
-    pub target_value: Option<f64>,
-    /// The target value as a string.
-    #[serde(default)]
-    pub target_value_string: Option<String>,
-    /// Additional configuration.
-    #[serde(default)]
-    pub config: Option<serde_json::Value>,
-    /// Creation timestamp.
-    #[serde(default)]
-    pub created_ts: Option<String>,
-    /// Last update timestamp.
-    #[serde(default)]
-    pub updated_ts: Option<String>,
+    pub last_updated_ts: Option<String>,
 }
 
 /// Query parameters for GET /structured_targets.


### PR DESCRIPTION
## Summary

Updates several model structs to match the actual field names and types returned by the Kalshi API. These changes fix deserialization failures that occur when the API returns different field names than expected.

### Changes

- **MilestoneInfo**: Rename fields to match API (`milestone_id` → `id`, add `category`, `notification_message`, `primary_event_tickers`, etc.)
- **StructuredTarget**: Rename fields (`structured_target_id` → `id`, `title` → `name`, add `source_id`, `details`)
- **IncentiveProgram**: Update fields to match API (add `incentive_type`, `market_ticker`, `period_reward`, `discount_factor_bps`, `paid_out`)
- **IncentiveProgramsResponse**: Rename `cursor` → `next_cursor`
- **QueuePositionsResponse**: Make `queue_positions` optional (API returns null when empty)
- **TagsByCategoriesResponse**: Make tag values optional (some categories have null tags)

Also includes formatting cleanup via `rustfmt`.

## Breaking Changes

| Type | Change |
|------|--------|
| `MilestoneInfo` | Field names changed to match API |
| `StructuredTarget` | Field names changed to match API |
| `IncentiveProgram` | Field names changed to match API |
| `IncentiveProgramsResponse` | `.cursor` renamed to `.next_cursor` |
| `QueuePositionsResponse` | `.queue_positions` is now `Option<Vec<_>>` |
| `TagsByCategoriesResponse` | Values are now `Option<Vec<String>>` |

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Manual testing with live API to verify deserialization