### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-17
+
 ### Removed
 
 - **Breaking:** `Fill::yes_price_fixed` and `Fill::no_price_fixed` — absent
@@ -14,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `Settlement::yes_total_cost` and `Settlement::no_total_cost`
   (i64 cents) — absent from the current Kalshi API. Use
   `yes_total_cost_dollars` / `no_total_cost_dollars`.
+
+### Fixed
+
+- Tolerate Fill/Settlement field drift in current Kalshi API — `Fill` now
+  accepts `yes_price_fixed`/`no_price_fixed` as optional; `Settlement` now
+  accepts `yes_total_cost`/`no_total_cost` (i64 cents) as optional. This
+  prevents deserialization errors if Kalshi re-enables these fields or if
+  responses vary between endpoints.
+- Default Market `subtitle`/`subtitle_si`/`subtitle_source` fields when the
+  API omits them, preventing deserialization failures on certain markets.
 
 ## [0.5.0] - 2026-03-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "kalshi-trade-rs"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kalshi-trade-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["pbeets"]
 description = "Rust client for the Kalshi trading API and WebSocket streams"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-kalshi-trade-rs = "0.5.0"
+kalshi-trade-rs = "0.6.0"
 ```
 
 Configure environment variables:


### PR DESCRIPTION
## Summary

- Bump version from 0.5.0 to 0.6.0 (minor bump due to breaking changes)
- Breaking: removed `Fill::yes_price_fixed`/`no_price_fixed` and `Settlement::yes_total_cost`/`no_total_cost` (i64 cents fields absent from current Kalshi API)
- Fix: tolerate Fill/Settlement field drift when API re-enables deprecated cents fields
- Fix: default Market `subtitle`/`subtitle_si`/`subtitle_source` when API omits them

### Changed files
- `Cargo.toml` — version 0.5.0 → 0.6.0
- `Cargo.lock` — version bump
- `CHANGELOG.md` — promoted [Unreleased] to [0.6.0], added new [Unreleased]
- `README.md` — dependency example updated