### PR TITLE
Update to recommended Kalshi API endpoints (external-api hosts)

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -307,8 +307,8 @@ Endpoints for accessing archived historical data past the cutoff timestamp.
 
 | Environment | REST API | WebSocket |
 |-------------|----------|-----------|
-| Demo | `https://demo-api.kalshi.co/trade-api/v2` | `wss://demo-api.kalshi.co/trade-api/ws/v2` |
-| Production | `https://api.elections.kalshi.com/trade-api/v2` | `wss://api.elections.kalshi.com/trade-api/ws/v2` |
+| Demo | `https://external-api.demo.kalshi.co/trade-api/v2` | `wss://external-api-ws.demo.kalshi.co/trade-api/ws/v2` |
+| Production | `https://external-api.kalshi.com/trade-api/v2` | `wss://external-api-ws.kalshi.com/trade-api/ws/v2` |
 
 ---
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -60,15 +60,15 @@ pub enum Environment {
 impl Environment {
     pub fn base_url(&self) -> &'static str {
         match self {
-            Environment::Demo => "https://demo-api.kalshi.co/trade-api/v2",
-            Environment::Prod => "https://api.elections.kalshi.com/trade-api/v2",
+            Environment::Demo => "https://external-api.demo.kalshi.co/trade-api/v2",
+            Environment::Prod => "https://external-api.kalshi.com/trade-api/v2",
         }
     }
 
     pub fn ws_url(&self) -> &'static str {
         match self {
-            Environment::Demo => "wss://demo-api.kalshi.co/trade-api/ws/v2",
-            Environment::Prod => "wss://api.elections.kalshi.com/trade-api/ws/v2",
+            Environment::Demo => "wss://external-api-ws.demo.kalshi.co/trade-api/ws/v2",
+            Environment::Prod => "wss://external-api-ws.kalshi.com/trade-api/ws/v2",
         }
     }
 


### PR DESCRIPTION
Kalshi has introduced dedicated `external-api` hosts for the Trade API. This PR updates the base URLs to the recommended endpoints per the [official docs](https://docs.kalshi.com/getting_started/api_environments).

### Changes

| Environment | Type | Old (Legacy) | New (Recommended) |
|---|---|---|---|
| Production | REST | `api.elections.kalshi.com` | `external-api.kalshi.com` |
| Production | WS | `api.elections.kalshi.com` | `external-api-ws.kalshi.com` |
| Demo | REST | `demo-api.kalshi.co` | `external-api.demo.kalshi.co` |
| Demo | WS | `demo-api.kalshi.co` | `external-api-ws.demo.kalshi.co` |

The old shared hosts remain supported, but the `external-api` hosts are dedicated to the external Trade API and are recommended for all API traders.

### Files changed
- `src/client.rs` — 4 URL constants in `Environment::base_url()` and `Environment::ws_url()`
- `src/api/README.md` — 2 rows in the base URL table

All 216 unit tests and 20 doc-tests pass.